### PR TITLE
Add folder for GRIB2 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@
 ### UI
 ![](https://github.com/Northern-Tornadoes-Project/MESH-MAP/blob/main/images/ui1.png)
 ![](https://github.com/Northern-Tornadoes-Project/MESH-MAP/blob/main/images/ui2.png)
+
+### GRIB2 Input Directory
+Place any GRIB2 files you want to process in the `grib2_files` folder at the repository root.

--- a/grib2_files/README.md
+++ b/grib2_files/README.md
@@ -1,0 +1,3 @@
+# GRIB2 Input Files
+
+Place your GRIB2 files in this directory. These files will be used as input for processing or analysis tools.


### PR DESCRIPTION
## Summary
- create `grib2_files` directory for GRIB2 data
- document the folder in the main README

## Testing
- `python3 -m py_compile $(ls python/*.py)`

------
https://chatgpt.com/codex/tasks/task_b_68450ab644b08331b4994f935bb35123