### PR TITLE
Add NOAA data fetch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,27 @@
 ### UI
 ![](https://github.com/Northern-Tornadoes-Project/MESH-MAP/blob/main/images/ui1.png)
 ![](https://github.com/Northern-Tornadoes-Project/MESH-MAP/blob/main/images/ui2.png)
+
+### GRIB2 Input Directory
+Place any GRIB2 files you want to process in the `grib2_files` folder at the repository root.  A helper script `python/download_mesh.py` can fetch a file directly from the NOAA MRMS AWS bucket and convert it to a GeoTIFF.
+
+### Usage
+1. Install the required Python packages and GDAL:
+   ```bash
+   sudo apt-get update && sudo apt-get install -y gdal-bin
+   pip install numpy opencv-python networkx tqdm Pillow requests rasterio
+   ```
+2. To retrieve MESH data for a date (e.g. `20240507`) and convert it to TIFF, run:
+   ```bash
+   python3 python/download_mesh.py 20240507
+   ```
+   The resulting TIFF will be written to `simple_images/`.
+3. Copy any other MESH `.tif` files into the `simple_images` folder. The main script expects them in this location.
+4. (Optional) Place additional GRIB2 data files in `grib2_files` for reference.
+5. Run the processing script from the repository root:
+   ```bash
+   python3 python/main.py
+   ```
+6. The processed images will be saved to `simple_images/results1/`.
+
+Note: The `python/download_mesh.py` helper downloads a single GRIB2 file for the start of the requested day and converts it to TIFF. The main processing script still requires TIFF input files.

--- a/grib2_files/README.md
+++ b/grib2_files/README.md
@@ -1,0 +1,3 @@
+# GRIB2 Input Files
+
+Place your GRIB2 files in this directory. These files will be used as input for processing or analysis tools.

--- a/python/download_mesh.py
+++ b/python/download_mesh.py
@@ -1,0 +1,49 @@
+import os
+import gzip
+import shutil
+import subprocess
+from datetime import datetime
+from pathlib import Path
+import requests
+
+
+def download_mesh_grib2(date_str, dest_dir='grib2_files'):
+    """Download MESH grib2 data for the given YYYYMMDD date.
+
+    Returns path to the downloaded grib2 file.
+    """
+    date = datetime.strptime(date_str, '%Y%m%d')
+    base_url = 'https://noaa-mrms-pds.s3.amazonaws.com/CONUS/MESH_00.50'
+    prefix = f"{date:%Y%m%d}"  # folder name in bucket
+    fname = f"MRMS_MESH_00.50_{date:%Y%m%d}-000000.grib2.gz"
+    url = f"{base_url}/{prefix}/{fname}"
+    Path(dest_dir).mkdir(parents=True, exist_ok=True)
+    gz_path = Path(dest_dir) / fname
+    resp = requests.get(url, stream=True)
+    resp.raise_for_status()
+    with open(gz_path, 'wb') as f:
+        for chunk in resp.iter_content(chunk_size=8192):
+            if chunk:
+                f.write(chunk)
+    grib2_path = gz_path.with_suffix('')
+    with gzip.open(gz_path, 'rb') as f_in:
+        with open(grib2_path, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+    return str(grib2_path)
+
+
+def grib2_to_tif(grib2_path, tif_path):
+    subprocess.check_call(['gdal_translate', grib2_path, tif_path])
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Download MESH GRIB2 and convert to TIFF')
+    parser.add_argument('date', help='Date in YYYYMMDD format')
+    parser.add_argument('--out', default='simple_images', help='Directory to store TIFF')
+    args = parser.parse_args()
+    grib2 = download_mesh_grib2(args.date)
+    Path(args.out).mkdir(parents=True, exist_ok=True)
+    tif = Path(args.out) / f"{args.date}.tif"
+    grib2_to_tif(grib2, tif)
+    print('Saved', tif)

--- a/simple_images/README.md
+++ b/simple_images/README.md
@@ -1,0 +1,3 @@
+# MESH TIFF Files
+
+Place any `.tif` files with MESH data in this directory. The `python/main.py` script processes all TIFF files found here and writes results to the `results1` subfolder.


### PR DESCRIPTION
## Summary
- add `download_mesh.py` script for grabbing MESH GRIB2 files from NOAA
- document how to use the helper and update install instructions

## Testing
- `python3 -m py_compile $(ls python/*.py)`

------
https://chatgpt.com/codex/tasks/task_b_68450ab644b08331b4994f935bb35123