### PR TITLE
Fix dependency handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
 test_images/
 simple_images/
-python/__pycache__
+python/__pycache__/
 python/.idea/
 MESH_MAP/.vs/
 MESH_MAP/obj/
 MESH_MAP/bin/
+# Swift build artifacts
+SwiftApp/.build/
+# Common Python artifacts
+.venv/
+__pycache__/
+*.pyc
+.build/

--- a/README.md
+++ b/README.md
@@ -13,3 +13,46 @@
 ### UI
 ![](https://github.com/Northern-Tornadoes-Project/MESH-MAP/blob/main/images/ui1.png)
 ![](https://github.com/Northern-Tornadoes-Project/MESH-MAP/blob/main/images/ui2.png)
+
+### GRIB2 Input Directory
+Place any GRIB2 files you want to process in the `grib2_files` folder at the repository root.  A helper script `python/download_mesh.py` can fetch a file directly from the NOAA MRMS AWS bucket and convert it to a GeoTIFF.
+
+### Usage
+1. Install GDAL and the Python dependencies:
+   ```bash
+   sudo apt-get update && sudo apt-get install -y gdal-bin
+   python3 -m pip install --upgrade pip
+   python3 -m pip install -r python/requirements.txt
+   ```
+2. To check which times are available for a date, you can list them with:
+   ```bash
+   python3 python/download_mesh.py 20240228 --product MESH_00.50 --list-times
+   ```
+3. To retrieve MESH data for a date (e.g. `20240507`) and convert it to TIFF, run:
+   ```bash
+   python3 python/download_mesh.py 20240507 --time 100000 \
+       --product MESH_Max_1440min_00.50 --out simple_images
+   ```
+   The resulting TIFF will be written to `simple_images/`.
+4. Copy any other MESH `.tif` files into the `simple_images` folder. The main script expects them in this location.
+5. (Optional) Place additional GRIB2 data files in `grib2_files` for reference. You can process them directly with:
+   ```bash
+   python3 python/process_grib2.py
+   ```
+   This converts each GRIB2 file to TIFF and writes the coloured output to `simple_images/results1/`.
+6. To run the pipeline on existing TIFF files only:
+   ```bash
+   python3 python/main.py
+   ```
+   Results are saved to `simple_images/results1/`.
+
+Note: The `python/download_mesh.py` helper downloads a single GRIB2 file for the specified product and time and converts it to TIFF. Use `--no-verify` if certificate errors occur when fetching from the NOAA bucket. The main processing script still requires TIFF input files.
+
+### macOS Command-Line Wrapper
+A Swift package in `SwiftApp` provides a convenience wrapper on macOS.
+Build and run with:
+```bash
+cd SwiftApp
+swift build -c release
+.build/release/MESHMapMac --date 20240507 --time 100000 --product MESH_Max_1440min_00.50
+```

--- a/SwiftApp/Package.swift
+++ b/SwiftApp/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:6.1
+import PackageDescription
+
+let package = Package(
+    name: "MESHMapMac",
+    platforms: [
+        .macOS(.v12)
+    ],
+    targets: [
+        .executableTarget(
+            name: "MESHMapMac",
+            dependencies: [],
+            resources: [
+                .copy("Resources/requirements.txt"),
+                .copy("Resources/install_python_deps.sh")
+            ],
+            .prebuildCommand(
+                displayName: "Install Python deps",
+                executable: .bash("Resources/install_python_deps.sh")
+            )
+        )
+    ]
+)

--- a/SwiftApp/README.md
+++ b/SwiftApp/README.md
@@ -1,0 +1,21 @@
+# MESHMapMac
+
+A minimal Swift command-line wrapper around the Python processing scripts.
+It downloads MRMS data and processes it via the existing pipeline.
+
+```
+Usage: MESHMapMac --date YYYYMMDD [--time HHMMSS] [--product PRODUCT]
+```
+
+Build with the Swift Package Manager:
+
+```
+cd SwiftApp
+swift build -c release
+```
+
+Run the tool after building (example):
+
+```
+.build/release/MESHMapMac --date 20240507 --time 100000 --product MESH_Max_1440min_00.50
+```

--- a/SwiftApp/Resources/install_python_deps.sh
+++ b/SwiftApp/Resources/install_python_deps.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python3 -m pip install --user -r "$(dirname "$0")/requirements.txt"

--- a/SwiftApp/Resources/requirements.txt
+++ b/SwiftApp/Resources/requirements.txt
@@ -1,0 +1,9 @@
+requests>=2.32
+numpy
+xarray
+netCDF4
+boto3
+opencv-python
+networkx
+tqdm
+Pillow

--- a/SwiftApp/Sources/MESHMapMac/main.swift
+++ b/SwiftApp/Sources/MESHMapMac/main.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct Options {
+    var date: String
+    var time: String = "000000"
+    var product: String = "MESH_00.50"
+}
+
+func parseArguments() -> Options? {
+    var opts = Options(date: "")
+    var iterator = CommandLine.arguments.dropFirst().makeIterator()
+    while let arg = iterator.next() {
+        switch arg {
+        case "--date":
+            if let value = iterator.next() { opts.date = value }
+        case "--time":
+            if let value = iterator.next() { opts.time = value }
+        case "--product":
+            if let value = iterator.next() { opts.product = value }
+        default:
+            break
+        }
+    }
+    return opts.date.isEmpty ? nil : opts
+}
+
+func runPython(script: String, args: [String]) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["python3", script] + args
+    process.standardInput = nil
+    process.standardOutput = FileHandle.standardOutput
+    process.standardError = FileHandle.standardError
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {
+        print("Failed to run \(script): \(error)")
+    }
+}
+
+if let opts = parseArguments() {
+    runPython(script: "../python/download_mesh.py", args: [opts.date, "--time", opts.time, "--product", opts.product])
+    runPython(script: "../python/main.py", args: [])
+} else {
+    print("Usage: MESHMapMac --date YYYYMMDD [--time HHMMSS] [--product PRODUCT]")
+}

--- a/grib2_files/README.md
+++ b/grib2_files/README.md
@@ -1,0 +1,3 @@
+# GRIB2 Input Files
+
+Place your GRIB2 files in this directory. These files will be used as input for processing or analysis tools.

--- a/python/download_mesh.py
+++ b/python/download_mesh.py
@@ -1,0 +1,100 @@
+import os
+import gzip
+import shutil
+import subprocess
+from datetime import datetime
+from pathlib import Path
+import requests
+from xml.etree import ElementTree
+
+
+def download_mesh_grib2(date_str, time_str='000000', product='MESH_00.50',
+                        dest_dir='grib2_files', verify=True):
+    """Download MESH GRIB2 data from the NOAA MRMS AWS bucket.
+
+    Parameters
+    ----------
+    date_str : str
+        Date in ``YYYYMMDD`` format.
+    time_str : str, optional
+        Time within the day, default ``"000000"``.
+    product : str, optional
+        MRMS product name such as ``"MESH_00.50"`` or
+        ``"MESH_Max_1440min_00.50"``.
+    dest_dir : str, optional
+        Directory to save the downloaded file.
+    verify : bool, optional
+        Set to ``False`` to skip TLS certificate verification.
+
+    Returns
+    -------
+    str
+        Path to the downloaded GRIB2 file.
+    """
+    date = datetime.strptime(date_str, '%Y%m%d')
+    base_url = f'https://noaa-mrms-pds.s3.amazonaws.com/CONUS/{product}'
+    prefix = f"{date:%Y%m%d}"
+    fname = f"MRMS_{product}_{date:%Y%m%d}-{time_str}.grib2.gz"
+    url = f"{base_url}/{prefix}/{fname}"
+    Path(dest_dir).mkdir(parents=True, exist_ok=True)
+    gz_path = Path(dest_dir) / fname
+    resp = requests.get(url, stream=True, verify=verify)
+    resp.raise_for_status()
+    with open(gz_path, 'wb') as f:
+        for chunk in resp.iter_content(chunk_size=8192):
+            if chunk:
+                f.write(chunk)
+    grib2_path = gz_path.with_suffix('')
+    with gzip.open(gz_path, 'rb') as f_in:
+        with open(grib2_path, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+    return str(grib2_path)
+
+
+def list_available_times(date_str, product='MESH_00.50', verify=True):
+    """Return a list of available HHMMSS strings for a date/product."""
+    url = (
+        "https://noaa-mrms-pds.s3.amazonaws.com?list-type=2&"
+        f"prefix=CONUS/{product}/{date_str}/"
+    )
+    resp = requests.get(url, verify=verify)
+    resp.raise_for_status()
+    root = ElementTree.fromstring(resp.content)
+    ns = "{http://s3.amazonaws.com/doc/2006-03-01/}"
+    times = []
+    for key in root.iter(ns + "Key"):
+        text = key.text
+        if text.endswith(".grib2.gz"):
+            t = text.split("-")[-1].split(".")[0]
+            times.append(t)
+    return sorted(times)
+
+
+def grib2_to_tif(grib2_path, tif_path):
+    subprocess.check_call(['gdal_translate', grib2_path, tif_path])
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Download MESH GRIB2 and convert to TIFF')
+    parser.add_argument('date', help='Date in YYYYMMDD format')
+    parser.add_argument('--time', default='000000', help='Time (HHMMSS) within the day')
+    parser.add_argument('--product', default='MESH_00.50',
+                        help='MRMS product name, e.g. MESH_00.50 or MESH_Max_1440min_00.50')
+    parser.add_argument('--out', default='simple_images', help='Directory to store TIFF')
+    parser.add_argument('--no-verify', action='store_true', help='Disable TLS certificate verification')
+    parser.add_argument('--list-times', action='store_true',
+                        help='List available times for the date/product and exit')
+    args = parser.parse_args()
+    if args.list_times:
+        times = list_available_times(args.date, args.product, verify=not args.no_verify)
+        for t in times:
+            print(t)
+    else:
+        grib2 = download_mesh_grib2(args.date, args.time, args.product,
+                                    dest_dir='grib2_files', verify=not args.no_verify)
+        Path(args.out).mkdir(parents=True, exist_ok=True)
+        tif_name = f"{args.product}_{args.date}-{args.time}.tif"
+        tif = Path(args.out) / tif_name
+        grib2_to_tif(grib2, tif)
+        print('Saved', tif)

--- a/python/process_grib2.py
+++ b/python/process_grib2.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Convert all GRIB2 files in grib2_files to GeoTIFF and run the
+existing MESH visualization pipeline on them."""
+
+try:
+    import requests
+except ImportError as e:
+    raise RuntimeError("Run `pip install -r python/requirements.txt`") from e
+
+from pathlib import Path
+import os
+from download_mesh import grib2_to_tif
+from main import process_tif
+
+
+def process_grib2_folder(src_dir="grib2_files", tif_dir="simple_images"):
+    src = Path(src_dir)
+    tif_out = Path(tif_dir)
+    tif_out.mkdir(parents=True, exist_ok=True)
+    for grib in src.glob("*.grib2"):
+        tif_path = tif_out / (grib.stem + ".tif")
+        grib2_to_tif(str(grib), str(tif_path))
+        process_tif(str(tif_path))
+
+
+if __name__ == "__main__":
+    process_grib2_folder()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,9 @@
+requests>=2.32
+numpy
+xarray
+netCDF4
+boto3
+opencv-python
+networkx
+tqdm
+Pillow

--- a/python/setup.sh
+++ b/python/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+python3 -m pip install --upgrade pip
+python3 -m pip install -r "$(dirname "$0")/requirements.txt"

--- a/simple_images/README.md
+++ b/simple_images/README.md
@@ -1,0 +1,3 @@
+# MESH TIFF Files
+
+Place any `.tif` files with MESH data in this directory. The `python/main.py` script processes all TIFF files found here and writes results to the `results1` subfolder.


### PR DESCRIPTION
## Summary
- add Python requirements and setup helper
- hook Swift build to install Python dependencies
- improve process_grib2 error message
- extend `.gitignore`
- document pip installation steps in README

## Testing
- `python3 -m py_compile $(ls python/*.py)`
- `python3 python/process_grib2.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68450ab644b08331b4994f935bb35123