### PR TITLE
Add macOS MRMS downloader app

### DIFF
--- a/MRMSDownloaderApp/MRMSDownloaderApp.swift
+++ b/MRMSDownloaderApp/MRMSDownloaderApp.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+@main
+struct MRMSDownloaderApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    @State private var selectedDate = Date()
+    @State private var outputFilename: String = ""
+    @State private var statusMessage: String? = nil
+
+    private let timestampFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateFormat = "yyyyMMdd-HHmmss"
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        return df
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Select Date and Time (UTC):")
+            DatePicker("", selection: $selectedDate, displayedComponents: [.date, .hourAndMinute])
+                .datePickerStyle(.fields)
+                .labelsHidden()
+                .onChange(of: selectedDate) { _ in
+                    updateDefaultFilename()
+                }
+
+            Text("Output Filename:")
+            TextField("", text: $outputFilename)
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+
+            Button("Download GRIB2 File") {
+                startDownload()
+            }
+            .padding(.vertical, 5)
+
+            if let message = statusMessage {
+                Text(message)
+                    .foregroundColor(message.starts(with: "Error") ? .red : .green)
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+        .onAppear {
+            updateDefaultFilename()
+        }
+    }
+
+    private func updateDefaultFilename() {
+        let ts = timestampFormatter.string(from: selectedDate)
+        outputFilename = "MRMS_MESH_Max_1440min_00.50_\(ts).grib2"
+    }
+
+    private func startDownload() {
+        statusMessage = "Downloading..."
+        let ts = timestampFormatter.string(from: selectedDate)
+        let remoteFile = "MRMS_MESH_Max_1440min_00.50_\(ts).grib2.gz"
+        let urlString = "https://noaa-mrms-pds.s3.amazonaws.com/CONUS/MESH_Max_1440min_00.50/\(remoteFile)"
+
+        guard let url = URL(string: urlString) else {
+            statusMessage = "Error: Malformed URL."
+            return
+        }
+
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                DispatchQueue.main.async {
+                    statusMessage = "Error: \(error.localizedDescription)"
+                }
+                return
+            }
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 404 {
+                    DispatchQueue.main.async {
+                        statusMessage = "Error: File not found on server (check date/time)."
+                    }
+                    return
+                } else if http.statusCode != 200 {
+                    DispatchQueue.main.async {
+                        statusMessage = "Error: Server returned status \(http.statusCode)."
+                    }
+                    return
+                }
+            }
+
+            guard let fileData = data else {
+                DispatchQueue.main.async {
+                    statusMessage = "Error: No data received (unknown issue)."
+                }
+                return
+            }
+
+            let desktop = FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first!
+            var destURL = desktop.appendingPathComponent(outputFilename)
+            if destURL.pathExtension.isEmpty {
+                destURL.appendPathExtension("grib2")
+            }
+
+            do {
+                try fileData.write(to: destURL)
+                DispatchQueue.main.async {
+                    statusMessage = "Download complete: \(destURL.lastPathComponent) saved to Desktop."
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    statusMessage = "Error: Failed to save file (\(error.localizedDescription))."
+                }
+            }
+        }
+        task.resume()
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -63,15 +63,10 @@ dependencies and builds the Swift wrapper so you can immediately run the tool.
 
 Note: The `python/download_mesh.py` helper downloads a single GRIB2 file for the specified product and time and converts it to TIFF. Use `--no-verify` if certificate errors occur when fetching from the NOAA bucket. The main processing script still requires TIFF input files.
 
+
 ### macOS Command-Line Wrapper
-A Swift package in `SwiftApp` provides a convenience wrapper on macOS. When run
-for the first time, it installs the required Python packages automatically.
-
-
-A Swift package in `SwiftApp` provides a convenience wrapper on macOS. When run
-for the first time, it installs the required Python packages automatically.
-A Swift package in `SwiftApp` provides a convenience wrapper on macOS.
-
+A Swift package in `SwiftApp` offers a command-line entry point that installs
+all Python dependencies on first run.
 
 Build and run with:
 ```bash
@@ -79,7 +74,6 @@ cd SwiftApp
 swift build -c release
 .build/release/MESHMapMac --date 20240507 --time 100000 --product MESH_Max_1440min_00.50
 ```
-
 
 ### Simple GUI
 A tiny Tkinter GUI can launch the download and processing pipeline.
@@ -89,3 +83,8 @@ python3 python/gui.py
 ```
 Fill in the date, time, and product then click **Download & Process**.
 The resulting TIFF and coloured output appear in `simple_images/`.
+
+### macOS Downloader App
+`MRMSDownloaderApp` is a simple SwiftUI application for downloading an MRMS
+MESH 1440‑minute GRIB2 file from NOAA's public AWS bucket. Open
+`MRMSDownloaderApp/MRMSDownloaderApp.swift` in Xcode and run the app to test.


### PR DESCRIPTION
## Summary
- add SwiftUI app `MRMSDownloaderApp` for downloading MRMS hail GRIB2 files
- document command-line wrapper, Tkinter GUI, and new macOS downloader app

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_68682aeeba248331b3787392a9c13001